### PR TITLE
Feat add ebs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 module "jinad" {
    source         = "jina-ai/jinad-aws/jina"
    version        = "0.0.5"
+   ebs = {
+     device_name = "/dev/sdh"
+     device_name_renamed = "/dev/xvdh"
+     mount_location = "/mnt/data"
+     jina_home = "/usr/local/jina"
+     }
    instances      = {
      "encoder": {
        "type": "c5.4xlarge",
@@ -68,6 +74,7 @@ with f:
 | Name |
 |------|
 | [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_ebs_volume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) |
 | [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) |
 | [aws_eip_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip_association) |
 | [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) |
@@ -77,6 +84,7 @@ with f:
 | [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) |
 | [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) |
+| [aws_volume_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) |
 | [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) |
 | [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) |
 | [random_string](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) |
@@ -86,7 +94,9 @@ with f:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tags | Additional resource tags | `map(string)` | `{}` | no |
-| instances | Describe instance configuration here. | `map(any)` | <pre>{<br>  "instance1": {<br>    "command": "sudo echo \"Hello from instance1\"",<br>    "pip": [<br>      "Pillow",<br>      "transformers"<br>    ],<br>    "type": "t2.micro"<br>  },<br>  "instance2": {<br>    "command": "sudo echo \"Hello from instance2\"",<br>    "pip": [<br>      "annoy"<br>    ],<br>    "type": "t2.micro"<br>  }<br>}</pre> | no |
+| availability\_zone | Mention the availability\_zone where JinaD resources are going to get created | `string` | `"us-east-1a"` | no |
+| ebs | Mention the settings of EBS which is attached to instance | `map(any)` | <pre>{<br>  "device_name": "/dev/sdh",<br>  "device_name_renamed": "/dev/xvdh",<br>  "jina_home": "/usr/local/jina",<br>  "mount_location": "/mnt/data"<br>}</pre> | no |
+| instances | Describe instance configuration here. | `map(any)` | <pre>{<br>  "instance1": {<br>    "command": "sudo echo \"Hello from instance1\"",<br>    "ebs": {<br>      "size": "20",<br>      "type": "gp2"<br>    },<br>    "pip": [<br>      "Pillow",<br>      "transformers"<br>    ],<br>    "type": "t2.micro"<br>  },<br>  "instance2": {<br>    "command": "sudo echo \"Hello from instance2\"",<br>    "ebs": {<br>      "size": "20",<br>      "type": "gp2"<br>    },<br>    "pip": [<br>      "annoy"<br>    ],<br>    "type": "t2.micro"<br>  }<br>}</pre> | no |
 | region | Mention the Region where JinaD resources are going to get created | `string` | `"us-east-1"` | no |
 | subnet\_cidr | Mention the CIDR of the subnet | `string` | `"10.113.0.0/16"` | no |
 | vpc\_cidr | Mention the CIDR of the VPC | `string` | `"10.113.0.0/16"` | no |

--- a/main.tf
+++ b/main.tf
@@ -144,8 +144,8 @@ resource "null_resource" "setup_jinad" {
     inline = [
       "sudo apt-get update",
       "sudo mkdir ${var.ebs.mountLocation}",
-      "sudo mkfs -t ext4 ${var.ebs.device_name}",
-      "sudo mount /dev/xvdh ${var.ebs.mountLocation}",
+      "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
+      "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mountLocation}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "null_resource" "setup_jinad" {
       "sudo apt-get update",
       "sudo mkdir ${var.ebs.mountLocation}",
       "sudo mkfs -t ext4 ${var.ebs.device_name}",
-      "sudo mount ${var.ebs.device_name} ${var.ebs.mountLocation}",
+      "sudo mount /dev/xvdh ${var.ebs.mountLocation}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",

--- a/main.tf
+++ b/main.tf
@@ -151,10 +151,10 @@ resource "null_resource" "setup_jinad" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt-get update",
-      "sudo mkdir ${var.ebs.mount_location}",
-      "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
-      "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mount_location}",
-      "sudo ln -s ${var.ebs.mount_location} ${var.ebs.jina_home}",
+      "sudo mkdir ${var.disk.mount_location}",
+      "sudo mkfs -t ext4 ${var.disk.device_name_renamed}",
+      "sudo mount ${var.disk.device_name_renamed} ${var.disk.mount_location}",
+      "sudo ln -s ${var.disk.mount_location} ${var.disk.jina_home}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
@@ -236,7 +236,7 @@ resource "aws_ebs_volume" "jinad_ebs_volume" {
 resource "aws_volume_attachment" "jinad_volume_attachment" {
   for_each = var.instances
 
-  device_name = var.ebs.device_name
+  device_name = var.disk.device_name
   volume_id = aws_ebs_volume.jinad_ebs_volume[each.key].id
   instance_id = aws_instance.jinad_instance[each.key].id
   force_detach = true

--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,7 @@ resource "null_resource" "setup_jinad" {
       "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
       "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mountLocation}",
       each.value.command,
-      "ln -s /mnt/data/ /usr/local/jina/",
+      "ln -s /mnt/data/ /usr/local/jina",
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
       "sudo bash jinad-init.sh ${join(" ", each.value.pip)}"

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,12 @@
  * module "jinad" {
  *    source         = "jina-ai/jinad-aws/jina"
  *    version        = "0.0.5"
+ *    ebs = {
+ *      device_name = "/dev/sdh"
+ *      device_name_renamed = "/dev/xvdh"
+ *      mount_location = "/mnt/data"
+ *      jina_home = "/usr/local/jina"
+ *      }
  *    instances      = {
  *      "encoder": {
  *        "type": "c5.4xlarge",

--- a/main.tf
+++ b/main.tf
@@ -144,8 +144,8 @@ resource "null_resource" "setup_jinad" {
     inline = [
       "sudo apt-get update",
       "sudo mkdir ${var.ebs.mountLocation}",
-      "sudo mkfs -t ext4 ${var.device_name}",
-      "sudo mount ${var.device_name} ${var.ebs.mountLocation}",
+      "sudo mkfs -t ext4 ${var.ebs.device_name}",
+      "sudo mount ${var.ebs.device_name} ${var.ebs.mountLocation}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
@@ -227,7 +227,7 @@ resource "aws_ebs_volume" "jinad_ebs_volume" {
 resource "aws_volume_attachment" "jinad_volume_attachment" {
   for_each = var.instances
 
-  device_name = var.device_name
+  device_name = var.ebs.device_name
   volume_id = aws_ebs_volume.jinad_ebs_volume[each.key].id
   instance_id = aws_instance.jinad_instance[each.key].id
 }

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,7 @@ resource "null_resource" "setup_jinad" {
       "sudo mkdir ${var.ebs.mount_location}",
       "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
       "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mount_location}",
+      "sudo ln -s ${var.ebs.mount_location} ${var.ebs.jina_home}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",

--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,9 @@ resource "null_resource" "setup_jinad" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt-get update",
+      "sudo mkdir ${var.ebs.mountLocation}",
+      "sudo mkfs -t ext4 ${var.device_name}",
+      "sudo mount ${var.device_name} ${var.ebs.mountLocation}",
       each.value.command,
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",

--- a/main.tf
+++ b/main.tf
@@ -6,22 +6,24 @@
  * module "jinad" {
  *    source         = "jina-ai/jinad-aws/jina"
  *    version        = "0.0.5"
- *    ebs = {
- *      device_name = "/dev/sdh"
- *      device_name_renamed = "/dev/xvdh"
- *      mount_location = "/mnt/data"
- *      jina_home = "/usr/local/jina"
- *      }
  *    instances      = {
- *      "encoder": {
- *        "type": "c5.4xlarge",
- *        "pip": [ "tensorflow>=2.0", "transformers>=2.6.0" ],
- *        "command": "sudo apt install -y jq"
+ *      encoder: {
+ *        type: "c5.4xlarge"
+ *        ebs = {
+ *          type = "gp2"
+ *          size = "20"
+ *        }
+ *        pip: [ "tensorflow>=2.0", "transformers>=2.6.0" ]
+ *        command: "sudo apt install -y jq"
  *      }
- *      "indexer": {
- *        "type": "i3.2xlarge",
- *        "pip": [ "faiss-cpu==1.6.5", "redis==3.5.3" ],
- *        "command": "sudo apt-get install -y redis-server && sudo redis-server --bind 0.0.0.0 --port 6379:6379 --daemonize yes"
+ *      indexer: {
+ *        type: "i3.2xlarge"
+ *        ebs = {
+ *          type = "gp2"
+ *          size = "20"
+ *        }
+ *        pip: [ "faiss-cpu==1.6.5", "redis==3.5.3" ]
+ *        command: "sudo apt-get install -y redis-server && sudo redis-server --bind 0.0.0.0 --port 6379:6379 --daemonize yes"
  *      }
  *    }
  *    vpc_cidr       = "34.121.0.0/24"

--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,8 @@ resource "aws_ebs_volume" "jina_ebs_volume" {
   availability_zone = var.availability_zone
   type = each.value.ebs.type
   size = each.value.ebs.size
+
+  tags = var.additional_tags
 }
 
 resource "aws_volume_attachment" "jina_volume_attachment" {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *    instances      = {
  *      encoder: {
  *        type: "c5.4xlarge"
- *        ebs = {
+ *        disk = {
  *          type = "gp2"
  *          size = "20"
  *        }
@@ -18,7 +18,7 @@
  *      }
  *      indexer: {
  *        type: "i3.2xlarge"
- *        ebs = {
+ *        disk = {
  *          type = "gp2"
  *          size = "20"
  *        }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_ebs_volume" "jinad_ebs_volume" {
 resource "aws_volume_attachment" "jinad_volume_attachment" {
   for_each = var.instances
 
-  device_name = "/dev/sdh"
+  device_name = var.device_name
   volume_id = aws_ebs_volume.jinad_ebs_volume[each.key].id
   instance_id = aws_instance.jinad_instance[each.key].id
 }

--- a/main.tf
+++ b/main.tf
@@ -230,4 +230,5 @@ resource "aws_volume_attachment" "jinad_volume_attachment" {
   device_name = var.ebs.device_name
   volume_id = aws_ebs_volume.jinad_ebs_volume[each.key].id
   instance_id = aws_instance.jinad_instance[each.key].id
+  force_detach = true
 }

--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,7 @@ resource "aws_internet_gateway" "jinad_ig" {
 }
 
 resource "aws_subnet" "jinad_vpc_subnet" {
+  availability_zone = var.availability_zone
   vpc_id     = aws_vpc.jinad_vpc.id
   cidr_block = var.subnet_cidr
   tags       = var.additional_tags

--- a/main.tf
+++ b/main.tf
@@ -143,11 +143,10 @@ resource "null_resource" "setup_jinad" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt-get update",
-      "sudo mkdir ${var.ebs.mountLocation}",
+      "sudo mkdir ${var.ebs.mount_location}",
       "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
-      "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mountLocation}",
+      "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mount_location}",
       each.value.command,
-      "ln -s /mnt/data/ /usr/local/jina",
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
       "sudo bash jinad-init.sh ${join(" ", each.value.pip)}"

--- a/main.tf
+++ b/main.tf
@@ -227,8 +227,8 @@ resource "aws_ebs_volume" "jinad_ebs_volume" {
   for_each = var.instances
 
   availability_zone = var.availability_zone
-  type = each.value.ebs.type
-  size = each.value.ebs.size
+  type = each.value.disk.type
+  size = each.value.disk.size
 
   tags = var.additional_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,7 @@ resource "null_resource" "setup_jinad" {
       "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
       "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mountLocation}",
       each.value.command,
+      "ln -s /mnt/data /usr/local/jina",
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
       "sudo bash jinad-init.sh ${join(" ", each.value.pip)}"

--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ resource "aws_route_table_association" "jinad_route_association" {
   route_table_id = aws_route_table.jinad_route_table.id
 }
 
-resource "aws_ebs_volume" "jina_ebs_volume" {
+resource "aws_ebs_volume" "jinad_ebs_volume" {
   for_each = var.instances
 
   availability_zone = var.availability_zone
@@ -221,10 +221,10 @@ resource "aws_ebs_volume" "jina_ebs_volume" {
   tags = var.additional_tags
 }
 
-resource "aws_volume_attachment" "jina_volume_attachment" {
+resource "aws_volume_attachment" "jinad_volume_attachment" {
   for_each = var.instances
 
   device_name = "/dev/sdh"
-  volume_id = aws_ebs_volume.jina_ebs_volume[each.key].id
+  volume_id = aws_ebs_volume.jinad_ebs_volume[each.key].id
   instance_id = aws_instance.jinad_instance[each.key].id
 }

--- a/main.tf
+++ b/main.tf
@@ -217,3 +217,11 @@ resource "aws_ebs_volume" "jina_ebs_volume" {
   type = each.value.ebs.type
   size = each.value.ebs.size
 }
+
+resource "aws_volume_attachment" "jina_volume_attachment" {
+  for_each = var.instances
+
+  device_name = "/dev/sdh"
+  volume_id = aws_ebs_volume.jina_ebs_volume[each.key].id
+  instance_id = aws_instance.jinad_instance[each.key].id
+}

--- a/main.tf
+++ b/main.tf
@@ -209,3 +209,11 @@ resource "aws_route_table_association" "jinad_route_association" {
   subnet_id      = aws_subnet.jinad_vpc_subnet.id
   route_table_id = aws_route_table.jinad_route_table.id
 }
+
+resource "aws_ebs_volume" "jina_ebs_volume" {
+  for_each = var.instances
+
+  availability_zone = var.availability_zone
+  type = each.value.ebs.type
+  size = each.value.ebs.size
+}

--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,7 @@ resource "null_resource" "setup_jinad" {
       "sudo mkfs -t ext4 ${var.ebs.device_name_renamed}",
       "sudo mount ${var.ebs.device_name_renamed} ${var.ebs.mountLocation}",
       each.value.command,
-      "ln -s /mnt/data /usr/local/jina",
+      "ln -s /mnt/data/ /usr/local/jina/",
       "curl -L https://raw.githubusercontent.com/jina-ai/cloud-ops/master/scripts/deb-systemd.sh > jinad-init.sh",
       "chmod +x jinad-init.sh",
       "sudo bash jinad-init.sh ${join(" ", each.value.pip)}"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,16 @@ variable "device_name" {
   default = "/dev/sdh"
 }
 
+variable "ebs" {
+  description = <<EOT
+    Mention the settings of EBS which is attached to instance
+    EOT
+  type = map(any)
+  default = {
+    mountLocation = "/mnt/data"
+  }
+}
+
 variable "instances" {
   description = <<EOT
     Describe instance configuration here.
@@ -40,7 +50,7 @@ variable "instances" {
       ]
       command = "sudo echo \"Hello from instance1\""
     }
-    instance = {
+    instance2 = {
       type = "t2.micro"
       ebs = {
         type = "gp2"

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,7 @@ variable "ebs" {
   type = map(any)
   default = {
     device_name = "/dev/sdh"
+    device_name_renamed = "/dev/xvdh"
     mountLocation = "/mnt/data"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,13 @@ variable "region" {
   default     = "us-east-1"
 }
 
+variable "availability_zone" {
+  description = <<EOT
+    Mention the availability_zone where JinaD resources are going to get created
+    EOT
+  type        = string
+  default     = "us-east-1a"
+}
 
 variable "instances" {
   description = <<EOT

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "ebs" {
   default = {
     device_name = "/dev/sdh"
     device_name_renamed = "/dev/xvdh"
-    mountLocation = "/mnt/data"
+    mount_location = "/mnt/data"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "ebs" {
     EOT
   type = map(any)
   default = {
+    device_name = "/dev/sdh"
     mountLocation = "/mnt/data"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,28 +20,28 @@ variable "instances" {
     EOT
   type        = map(any)
   default = {
-    "instance1" = {
-      "type" = "t2.micro"
-      "ebs" = {
+    instance1 = {
+      type = "t2.micro"
+      ebs = {
         type = "gp2"
         size = "20"
       }
-      "pip" = [
+      pip = [
         "Pillow",
         "transformers"
-      ],
-      "command" = "sudo echo \"Hello from instance1\""
-    },
-    "instance2" = {
-      "type" = "t2.micro"
-      "ebs" = {
+      ]
+      command = "sudo echo \"Hello from instance1\""
+    }
+    instance = {
+      type = "t2.micro"
+      ebs = {
         type = "gp2"
         size = "20"
       }
-      "pip" = [
+      pip = [
         "annoy",
-      ],
-      "command" = "sudo echo \"Hello from instance2\""
+      ]
+      command = "sudo echo \"Hello from instance2\""
     },
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,7 @@ variable "ebs" {
     device_name = "/dev/sdh"
     device_name_renamed = "/dev/xvdh"
     mount_location = "/mnt/data"
+    jina_home = "/usr/local/jina"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "availability_zone" {
   default     = "us-east-1a"
 }
 
-variable "ebs" {
+variable "disk" {
   description = <<EOT
     Mention the settings of EBS which is attached to instance
     EOT
@@ -35,7 +35,7 @@ variable "instances" {
   default = {
     instance1 = {
       type = "t2.micro"
-      ebs = {
+      disk = {
         type = "gp2"
         size = "20"
       }
@@ -47,7 +47,7 @@ variable "instances" {
     }
     instance2 = {
       type = "t2.micro"
-      ebs = {
+      disk = {
         type = "gp2"
         size = "20"
       }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,10 @@ variable "instances" {
   default = {
     "instance1" = {
       "type" = "t2.micro"
+      "ebs" = {
+        type = "gp2"
+        size = "20"
+      }
       "pip" = [
         "Pillow",
         "transformers"
@@ -23,6 +27,10 @@ variable "instances" {
     },
     "instance2" = {
       "type" = "t2.micro"
+      "ebs" = {
+        type = "gp2"
+        size = "20"
+      }
       "pip" = [
         "annoy",
       ],

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,14 @@ variable "availability_zone" {
   default     = "us-east-1a"
 }
 
+variable "device_name" {
+  description = <<EOT
+    Mention the device name of EBS which is attached to instance
+    EOT
+  type = string
+  default = "/dev/sdh"
+}
+
 variable "instances" {
   description = <<EOT
     Describe instance configuration here.

--- a/variables.tf
+++ b/variables.tf
@@ -58,8 +58,6 @@ variable "instances" {
   }
 }
 
-
-
 variable "vpc_cidr" {
   description = <<EOT
     Mention the CIDR of the VPC
@@ -68,7 +66,6 @@ variable "vpc_cidr" {
   default     = "10.113.0.0/16"
 }
 
-
 variable "subnet_cidr" {
   description = <<EOT
     Mention the CIDR of the subnet
@@ -76,7 +73,6 @@ variable "subnet_cidr" {
   type        = string
   default     = "10.113.0.0/16"
 }
-
 
 variable "additional_tags" {
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -14,14 +14,6 @@ variable "availability_zone" {
   default     = "us-east-1a"
 }
 
-variable "device_name" {
-  description = <<EOT
-    Mention the device name of EBS which is attached to instance
-    EOT
-  type = string
-  default = "/dev/sdh"
-}
-
 variable "ebs" {
   description = <<EOT
     Mention the settings of EBS which is attached to instance


### PR DESCRIPTION
With using  only 8G root device, when we install big-size python packages, it shows error that `no left space left on device`.
Now, we add EBS to our instance:

- deploy `aws_ebs_volume`
- deploy `aws_volume_attachment`
- make file system for `aws_ebs_volume`
- mount  `aws_ebs_volume` to instance
- make a soft link from `/mnt/data/`(source) to `/usr/local/jina`(target)